### PR TITLE
prevent script tags to include source.js when the node is a ng-template ...

### DIFF
--- a/Syntaxes/Jade.JSON-tmLanguage
+++ b/Syntaxes/Jade.JSON-tmLanguage
@@ -28,7 +28,7 @@
       ]
     },
     {
-      "begin": "^(\\s*)(script)(?=[.#(\\s])",
+      "begin": "^(\\s*)(script)(?=[.#(\\s])(?![^\\n]*ng-template)",
       "beginCaptures": { "2": { "name": "entity.name.tag.script.jade" } },
       "end": "^(?!(\\1\\s)|\\s*$)",
       "name": "source.script.jade",

--- a/Syntaxes/Jade.tmLanguage
+++ b/Syntaxes/Jade.tmLanguage
@@ -59,7 +59,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(\s*)(script)(?=[.#(\s])</string>
+			<string>^(\s*)(script)(?=[.#(\s])(?![^\n]*ng-template)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>


### PR DESCRIPTION
ng-template script nodes have raw HTML in them and thus should not be interpreted as javascript.

That being said, maybe the detection could be extended for anything that has a type="..." that is different from text/javascript ?
