### PR TITLE
Allow :coffee-script filter to highlight as coffeescript.

### DIFF
--- a/Syntaxes/Jade.JSON-tmLanguage
+++ b/Syntaxes/Jade.JSON-tmLanguage
@@ -114,7 +114,7 @@
       ]
     },
     {
-      "begin": "^(\\s*):(coffee(script)?)(?=\\(|$)",
+      "begin": "^(\\s*):(coffee(-?script)?)(?=\\(|$)",
       "beginCaptures": { "2": { "name": "constant.language.name.coffeescript.filter.jade" } },
       "end": "^(?!(\\1\\s)|\\s*$)",
       "name": "source.coffeescript.filter.jade",

--- a/Syntaxes/Jade.tmLanguage
+++ b/Syntaxes/Jade.tmLanguage
@@ -277,7 +277,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(\s*):(coffee(script)?)(?=\(|$)</string>
+			<string>^(\s*):(coffee(-?script)?)(?=\(|$)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>

--- a/Syntaxes/PyJade.tmLanguage
+++ b/Syntaxes/PyJade.tmLanguage
@@ -278,7 +278,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(\s*):(coffee(script)?)(?=\(|$)</string>
+			<string>^(\s*):(coffee(-?script)?)(?=\(|$)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>


### PR DESCRIPTION
In Jade `:coffee` and `:coffeescript` is deprecated in favor of `:coffee-script` used by JSTransformers:
https://github.com/jstransformers/list-of-jstransformers/blob/master/list-of-jstransformers.json

The full deprecation message:
```
Transformers.coffee is deprecated, you must replace the :coffee jade filter, with :coffee-script and install jstransformer-coffee-script before you update to jade@2.0.0.
```