### PR TITLE
Support for HTML comments

### DIFF
--- a/Syntaxes/Jade.JSON-tmLanguage
+++ b/Syntaxes/Jade.JSON-tmLanguage
@@ -28,6 +28,17 @@
       ]
     },
     {
+      "begin": "<!--",
+      "end": "--\\s*>",
+      "name": "comment.unbuffered.block.jade",
+      "patterns": [
+        {
+          "match": "--",
+          "name": "invalid.illegal.comment.comment.block.jade"
+        }
+      ]
+    },
+    {
       "begin": "^(\\s*)-$",
       "end": "^(?!(\\1\\s)|\\s*$)",
       "name": "source.js",

--- a/Syntaxes/Jade.tmLanguage
+++ b/Syntaxes/Jade.tmLanguage
@@ -59,6 +59,23 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>&lt;!--</string>
+			<key>end</key>
+			<string>--\s*&gt;</string>
+			<key>name</key>
+			<string>comment.buffered.block.jade</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>--</string>
+					<key>name</key>
+					<string>invalid.illegal.comment.comment.block.jade</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>^(\s*)-$</string>
 			<key>comment</key>
 			<string>Unbuffered code block.</string>

--- a/Syntaxes/PyJade.tmLanguage
+++ b/Syntaxes/PyJade.tmLanguage
@@ -31,6 +31,23 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>&lt;!--</string>
+			<key>end</key>
+			<string>--\s*&gt;</string>
+			<key>name</key>
+			<string>comment.buffered.block.jade</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>--</string>
+					<key>name</key>
+					<string>invalid.illegal.comment.comment.block.jade</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>^(\s*)//</string>
 			<key>comment</key>
 			<string>Buffered (html) comments.</string>

--- a/test_jades/test.jade
+++ b/test_jades/test.jade
@@ -4,6 +4,15 @@ doctype html
 _test  =  [{abc: "lalal"}]
 name = function() {}
 
+<!-- This is HTML comment. -->
+
+<!--[if IE 8]>
+<html lang="en" class="lt-ie9">
+<![endif]-->
+<!--[if gt IE 8]><!-->
+html(lang="en")
+<!--<![endif]-->
+
 html
   head
     script#idscript.script(type="text/javascript",   qwerqwer)(test="123", lol=(1+


### PR DESCRIPTION
Hello, @davidrios, 

I'm working on improving support for the Jade/Pug syntax in VS Code and one of requests - support HTML comments. 

Original issue: https://github.com/Microsoft/vscode/pull/11764

This PR is fix for https://github.com/Microsoft/vscode/issues/3202.

**Before fix (Sublime Text 3 with you package):**

![image](https://cloud.githubusercontent.com/assets/7034281/18392366/330c480a-76ba-11e6-9518-07c24e6f35c1.png)

**After fix (Sublime Text 3 with you package):**

![image](https://cloud.githubusercontent.com/assets/7034281/18392297/f7cc882c-76b9-11e6-8b79-18ec8e203d5d.png)
