### PR TITLE
"tag_classes" must be treated as css classes

### DIFF
--- a/Syntaxes/Jade.JSON-tmLanguage
+++ b/Syntaxes/Jade.JSON-tmLanguage
@@ -399,7 +399,7 @@
     "tag_classes": {
       "match": "\\.([^\\w-])?[\\w-]*",
       "captures": { "1": { "name": "invalid.illegal.tag.jade" } },
-      "name": "entity.other.attribute-name.class.jade"
+      "name": "entity.other.attribute-name.class.css.jade"
     },
     "tag_attributes": {
       "begin": "(\\(\\s*)",

--- a/Syntaxes/Jade.tmLanguage
+++ b/Syntaxes/Jade.tmLanguage
@@ -364,7 +364,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.other.attribute-name.class.jade</string>
+					<string>entity.other.attribute-name.class.css.jade</string>
 				</dict>
 				<key>4</key>
 				<dict>

--- a/Syntaxes/PyJade.tmLanguage
+++ b/Syntaxes/PyJade.tmLanguage
@@ -1406,7 +1406,7 @@
 			<key>match</key>
 			<string>\.([^\w-])?[\w-]*</string>
 			<key>name</key>
-			<string>constant.language.js</string>
+			<string>entity.other.attribute-name.class.css.jade</string>
 		</dict>
 		<key>tag_id</key>
 		<dict>


### PR DESCRIPTION
Syntax for classes was not treated as css classes but as attributes.  
It is not good because difference occured between css meta languages.